### PR TITLE
Add WebSocket trigger node

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Here's an example of how to use the AWS WebSocket node in a workflow:
 4. Set the Connection ID and Message fields
 5. Execute the workflow
 
+### WebSocket Trigger Node
+
+This package also provides a *WebSocket Trigger* node which connects to any WebSocket server and triggers the workflow whenever a message is received. Configure the node with the WebSocket URL and the incoming messages will be passed as JSON with a `message` field.
+
 ## Development
 
 If you want to develop and modify this node:

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -21,6 +21,7 @@ This project implements a custom n8n node that allows sending messages to AWS AP
 - **Node Implementation**:
   - `nodes/AwsWebSocket/AwsWebSocket.node.ts`: Main node implementation
   - `nodes/AwsWebSocket/awsWebSocket.svg`: Node icon
+  - `nodes/WebSocketTrigger/WebSocketTrigger.node.ts`: Trigger node for incoming WebSocket messages
 
 - **Credential Handling**:
   - `credentials/AwsWebSocketApi.credentials.ts`: AWS credential type definition

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,10 @@
 import { AwsWebSocket } from './nodes/AwsWebSocket/AwsWebSocket.node';
+import { WebSocketTrigger } from './nodes/WebSocketTrigger/WebSocketTrigger.node';
 import { AwsWebSocketApi } from './credentials/AwsWebSocketApi.credentials';
 
 export const nodeTypes = {
   AwsWebSocket,
+  WebSocketTrigger,
 };
 
 export const credentialTypes = {

--- a/nodes/WebSocketTrigger/WebSocketTrigger.node.ts
+++ b/nodes/WebSocketTrigger/WebSocketTrigger.node.ts
@@ -1,0 +1,65 @@
+import WebSocket from 'ws';
+import {
+  ITriggerFunctions,
+  INodeType,
+  INodeTypeDescription,
+  ITriggerResponse,
+  NodeConnectionType,
+  NodeOperationError,
+} from 'n8n-workflow';
+
+export class WebSocketTrigger implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'WebSocket Trigger',
+    name: 'webSocketTrigger',
+    icon: 'fa:exchange-alt',
+    group: ['trigger'],
+    version: 1,
+    description: 'Listens for messages from a WebSocket server',
+    defaults: {
+      name: 'WebSocket Trigger',
+    },
+    inputs: [],
+    outputs: [NodeConnectionType.Main],
+    properties: [
+      {
+        displayName: 'WebSocket URL',
+        name: 'url',
+        type: 'string',
+        required: true,
+        default: '',
+        placeholder: 'wss://example.com/socket',
+        description: 'The WebSocket server URL to connect to',
+      },
+    ],
+  };
+
+  async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
+    const url = this.getNodeParameter('url') as string;
+
+    let ws: WebSocket;
+
+    const connect = () => {
+      ws = new WebSocket(url);
+
+      ws.on('message', (data: WebSocket.RawData) => {
+        const message = data.toString();
+        this.emit([this.helpers.returnJsonArray([{ message }])]);
+      });
+
+      ws.on('error', (error: Error) => {
+        this.emitError(new NodeOperationError(this.getNode(), error));
+      });
+    };
+
+    connect();
+
+    const closeFunction = async () => {
+      if (ws.readyState === WebSocket.OPEN) ws.close();
+    };
+
+    return {
+      closeFunction,
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "@aws-sdk/client-apigatewaymanagementapi": "^3.400.0",
     "@aws-sdk/credential-provider-ini": "^3.400.0",
     "n8n-core": "^1.0.0",
-    "n8n-workflow": "^1.0.0"
+    "n8n-workflow": "^1.0.0",
+    "ws": "^8.15.0"
   },
   "devDependencies": {
     "@types/node": "^18.16.0",
+    "@types/ws": "^8.18.1",
     "jest": "^29.5.0",
     "typescript": "^5.0.4"
   },
@@ -35,7 +37,8 @@
       "dist/credentials/AwsWebSocketApi.credentials.js"
     ],
     "nodes": [
-      "dist/nodes/AwsWebSocket/AwsWebSocket.node.js"
+      "dist/nodes/AwsWebSocket/AwsWebSocket.node.js",
+      "dist/nodes/WebSocketTrigger/WebSocketTrigger.node.js"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add a WebSocket trigger node for receiving messages
- expose the trigger node in the module entry
- document the new node in README and SUMMARY
- include `ws` and `@types/ws` dependencies

## Testing
- `npm run build`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68405af68b08832e87d8c7dd2c1ba517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Adicionado um novo node "WebSocket Trigger" que permite conectar-se a qualquer servidor WebSocket e acionar fluxos de trabalho ao receber mensagens.
- **Documentação**
  - Atualizada a documentação para incluir instruções e informações sobre o novo node "WebSocket Trigger".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->